### PR TITLE
修复当EndlessRecyclerView显示的总数在一屏内自动加载的问题

### DIFF
--- a/recycler/src/main/java/com/mcxiaoke/next/recycler/EndlessRecyclerView.java
+++ b/recycler/src/main/java/com/mcxiaoke/next/recycler/EndlessRecyclerView.java
@@ -128,6 +128,11 @@ public class EndlessRecyclerView extends RecyclerView {
         @Override
         public void onScrolled(final RecyclerView recyclerView, final int dx, final int dy) {
             super.onScrolled(recyclerView, dx, dy);
+        }
+
+        @Override
+        public void onScrollStateChanged(final RecyclerView recyclerView, final int newState) {
+            super.onScrollStateChanged(recyclerView, newState);
             LogUtils.v(TAG, "onScrolled() state=" + mViewState);
             if (mViewState.mode != MODE_AUTO) {
                 return;
@@ -135,11 +140,11 @@ public class EndlessRecyclerView extends RecyclerView {
             if (mLoading) {
                 return;
             }
-            final RecyclerViewHelper mRecyclerViewHelper = new RecyclerViewHelper(recyclerView);
+            final RecyclerViewHelper recyclerViewHelper = new RecyclerViewHelper(recyclerView);
             final int threshold = mViewState.getThreshold();
             int visibleItemCount = recyclerView.getChildCount();
-            int totalItemCount = mRecyclerViewHelper.getItemCount();
-            int firstVisibleItem = mRecyclerViewHelper.findFirstVisibleItemPosition();
+            int totalItemCount = recyclerViewHelper.getItemCount();
+            int firstVisibleItem = recyclerViewHelper.findFirstVisibleItemPosition();
             if ((totalItemCount - visibleItemCount)
                     <= (firstVisibleItem + threshold)) {
                 mViewState.incIndex();
@@ -150,11 +155,6 @@ public class EndlessRecyclerView extends RecyclerView {
                     mLoadMoreListener.onLoadMore(mRecyclerView);
                 }
             }
-        }
-
-        @Override
-        public void onScrollStateChanged(final RecyclerView recyclerView, final int newState) {
-            super.onScrollStateChanged(recyclerView, newState);
         }
     };
 

--- a/samples/src/main/java/com/mcxiaoke/next/samples/EndlessRecyclerViewSamples.java
+++ b/samples/src/main/java/com/mcxiaoke/next/samples/EndlessRecyclerViewSamples.java
@@ -3,8 +3,7 @@ package com.mcxiaoke.next.samples;
 import android.annotation.TargetApi;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
-import butterknife.ButterKnife;
-import butterknife.InjectView;
+
 import com.mcxiaoke.next.recycler.EndlessRecyclerView;
 import com.mcxiaoke.next.recycler.EndlessRecyclerView.OnLoadMoreListener;
 import com.mcxiaoke.next.task.SimpleTaskCallback;
@@ -14,6 +13,9 @@ import com.mcxiaoke.next.task.TaskQueue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+
+import butterknife.ButterKnife;
+import butterknife.InjectView;
 
 /**
  * EndlessListView使用示例


### PR DESCRIPTION
判断是否加载增加当前状态的限制，只有状态不为SCROLL_STATE_IDLE才
加载