### PR TITLE
将ProgressRequestBody中的原始RequestBody对外暴露

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 
 这个库是我在日常开发过程中积累下来的一些可复用组件，大部分都在我的工作项目和个人项目中有使用。
 
-最新版本: [![Maven Central](http://img.shields.io/badge/2018.06.18-com.mcxiaoke.next:core:1.5.3-brightgreen.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mcxiaoke.next%22)
+最新版本: [![Maven Central](http://img.shields.io/badge/2018.06.18-com.mcxiaoke.next:core:1.5.4-brightgreen.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mcxiaoke.next%22)
 
 ## Gradle集成
 
 ```groovy
     // core 核心库, 格式:jar和aar
-    compile 'com.mcxiaoke.next:core:1.5.3'
+    compile 'com.mcxiaoke.next:core:1.5.4'
     // task 异步任务库，格式:jar和aar
-    compile 'com.mcxiaoke.next:task:1.5.3'
+    compile 'com.mcxiaoke.next:task:1.5.4'
     // http HTTP组件, 格式:jar和aar
-    compile 'com.mcxiaoke.next:http:1.5.3'
+    compile 'com.mcxiaoke.next:http:1.5.4'
     // 函数操作组件
-    compile 'com.mcxiaoke.next:functions:1.5.3'
+    compile 'com.mcxiaoke.next:functions:1.5.4'
     // ui UI组件, 格式:aar
-    compile 'com.mcxiaoke.next:ui:1.5.3'
+    compile 'com.mcxiaoke.next:ui:1.5.4'
     // recycler EndlessRecyclerView, 格式:aar
-    compile 'com.mcxiaoke.next:recycler:1.5.3'
+    compile 'com.mcxiaoke.next:recycler:1.5.4'
     // extra-abc 依赖support-v7 AppCompat 格式:aar
-    compile 'com.mcxiaoke.next:extras-abc:1.5.3'
+    compile 'com.mcxiaoke.next:extras-abc:1.5.4'
 
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=1.5.3
-VERSION_CODE=1503
+VERSION_NAME=1.5.4
+VERSION_CODE=1504
 GROUP=com.mcxiaoke.next
 
 POM_DESCRIPTION=Android Next Components: Cache, Task, Views, Widgets, Utils

--- a/http/src/main/java/com/mcxiaoke/next/http/ProgressRequestBody.java
+++ b/http/src/main/java/com/mcxiaoke/next/http/ProgressRequestBody.java
@@ -37,6 +37,14 @@ public class ProgressRequestBody extends RequestBody {
         return body.contentLength();
     }
 
+    public RequestBody getBody() {
+        return body;
+    }
+
+    public ProgressListener getListener() {
+        return listener;
+    }
+
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
         if (buffer == null) {


### PR DESCRIPTION
当支持ProgressListener时，代码这里
https://github.com/mcxiaoke/Android-Next/blob/master/http/src/main/java/com/mcxiaoke/next/http/NextRequest.java#L376，
外部的调用者希望能够拿到原始RequestBody参数，以便业务定制化，比如在SignatureInterceptor中添加签名信息。